### PR TITLE
Update dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "react", "stage-1"],
+  "plugins": ["transform-runtime"]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/takanabe/react-redux-material_ui-boilerplate.git"
   },
   "keywords": [
     "React",
@@ -22,29 +22,32 @@
   "author": "https://github.com/takanabe",
   "license": "MIT",
   "bugs": {
-    "url": ""
+    "url": "https://github.com/takanabe/react-redux-material_ui-boilerplate/issues"
   },
   "homepage": "",
   "devDependencies": {
-    "babel-core": "^5.8.25",
-    "babel-eslint": "^4.1.3",
-    "babel-loader": "^5.3.2",
-    "babel-runtime": "^5.8.25",
-    "css-loader": "^0.19.0",
-    "eslint": "^1.6.0",
-    "eslint-loader": "^1.1.0",
-    "eslint-plugin-react": "^3.5.1",
-    "fbjs": "^0.2.1",
-    "file-loader": "^0.8.4",
-    "style-loader": "^0.12.4",
-    "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.0",
-    "webpack-hot-middleware": "^2.2.0"
+    "babel-core": "^6.7.6",
+    "babel-eslint": "^6.0.3",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-transform-runtime": "^6.7.5",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-1": "^6.5.0",
+    "babel-runtime": "^6.6.1",
+    "css-loader": "^0.23.1",
+    "eslint": "^2.8.0",
+    "eslint-loader": "^1.3.0",
+    "eslint-plugin-react": "^5.0.1",
+    "file-loader": "^0.8.5",
+    "style-loader": "^0.13.1",
+    "webpack": "^1.13.0",
+    "webpack-dev-server": "^1.14.1",
+    "webpack-hot-middleware": "^2.10.0"
   },
   "dependencies": {
-    "classnames": "^2.1.2",
-    "fbjs": "^0.3.2",
-    "material-ui": "^0.14.0",
+    "classnames": "^2.2.3",
+    "fbjs": "^0.8.1",
+    "material-ui": "^0.14.4",
     "react": "^0.14.0",
     "react-addons-create-fragment": "^0.14.0",
     "react-addons-pure-render-mixin": "^0.14.0",
@@ -52,8 +55,8 @@
     "react-addons-update": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-hot-loader": "^1.3.0",
-    "react-redux": "^3.1.0",
-    "react-tap-event-plugin": "^0.2.0",
-    "redux": "^3.0.2"
+    "react-redux": "^4.4.5",
+    "react-tap-event-plugin": "^0.2.2",
+    "redux": "^3.5.0"
   }
 }

--- a/store/configureStore.jsx
+++ b/store/configureStore.jsx
@@ -2,7 +2,11 @@ import { createStore } from 'redux';
 import rootReducer from '../reducers';
 
 export default function configureStore(initialState) {
-  const store = createStore(rootReducer, initialState);
+  const store = createStore(
+    rootReducer,
+    initialState,
+    window.devToolsExtension ? window.devToolsExtension() : undefined
+  );
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,9 @@
 module.exports = {
-  context: __dirname + "/src",
+  context: __dirname,
   entry: {
-    jsx: "./index.jsx",
-    css: "./main.css",
-    html: "./index.html",
+    jsx: "./src/index.jsx",
+    css: "./src/main.css",
+    html: "./src/index.html",
   },
 
   output: {
@@ -13,12 +13,12 @@ module.exports = {
   module: {
     preLoaders: [
         //Eslint loader
-      { test: /\.(js|jsx)$/, exclude: /node_modules/, loader: "eslint-loader"},
+      { test: /\.jsx?$/, exclude: /node_modules/, loader: "eslint-loader"},
     ],
     loaders: [
       { test: /\.html$/, loader: "file?name=[name].[ext]" },
       { test: /\.css$/, loader: "file?name=[name].[ext]" },
-      { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: ["react-hot","babel-loader?stage=0&optional=runtime"]},
+      { test: /\.jsx?$/, exclude: /node_modules/, loaders: ["react-hot","babel-loader"]},
     ],
   },
   resolve: {


### PR DESCRIPTION
Thanks for this boilerplate repo.  I used it for my latest project and it was a great starting point.  I just updated the dependencies in said project so I thought I'd return the favor and update this repo.

For Babel 6, I replaced invalid loader config options with presets and plugins in a new `.babelrc` file.

I had to make another modification to get it to build on my system.  The `context` field in `webpack.config.js` is now just `__dirname`, and each `entry` point now includes the `./src` part of the path.

I was going to update `react` to `15.0.1`, but the `material-ui` version that includes React 15 compatibility is still in [beta](https://github.com/callemall/material-ui/releases/tag/v0.15.0-beta.1).  Maybe in a few more weeks.
