### PR TITLE
Fixed URL, former domain is now for sale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # react-redux-material_ui-boilerplate
-A boilerplate for React + Redux + Material UI + ES6 syntax applications. This boilerplate includes following tools and frameworks.
+A boilerplate for React + Redux + Material UI + ES6 syntax applications. This boilerplate includes the following tools and frameworks:
 
 * [React](https://facebook.github.io/react/)
-* [Redux](http://rackt.org/redux/index.html)
+* [Redux](https://reduxframework.com/)
 * [Material UI](http://material-ui.com/#/)
 * [webpack](https://webpack.github.io/)
 * [Babel](https://babeljs.io/)
@@ -27,13 +27,13 @@ $ npm install
 ```
 
 ## Use development server
-For development server, webpack-dev-server is reasonable. It monitors update files and rebuild them automatically. Since webpack cli command is registerd in `package.json` in this project, just type following command to run webpack-dev-server.
+For development server, webpack-dev-server is reasonable. It monitors update files and rebuild them automatically. Since the webpack cli command is registerd in `package.json` in this project, just type the following command to run webpack-dev-server:
 
 ```bash
 $ npm start
 ```
 
-Becareful! the webpack-dev-server rebuild files in `src` automatically but the bundled files are just placed on its memory. Build manually by allowing next section(Build assets), if you want need the bundled files.
+Be careful! The webpack-dev-server rebuilds files in `src` automatically but the bundled files are just placed on its memory. Build manually by allowing next section (Build assets), if you want need the bundled files.
 
 
 ## Build assets

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A boilerplate for React + Redux + Material UI + ES6 syntax applications. This boilerplate includes the following tools and frameworks:
 
 * [React](https://facebook.github.io/react/)
-* [Redux](https://reduxframework.com/)
+* [Redux](http://redux.js.org/)
 * [Material UI](http://material-ui.com/#/)
 * [webpack](https://webpack.github.io/)
 * [Babel](https://babeljs.io/)


### PR DESCRIPTION
New URL found in the description fields at https://github.com/reduxframework/redux-framework
- minor grammar fixes
