### PR TITLE
Fix npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "classnames": "^2.2.5",
     "fbjs": "^0.8.5",
     "material-ui": "^0.16.0",
-    "react": "^15.3.2",
+    "react": "^15.4.0",
     "react-addons-create-fragment": "^15.3.2",
     "react-addons-pure-render-mixin": "^15.3.2",
     "react-addons-transition-group": "^15.3.2",
@@ -56,7 +56,7 @@
     "react-dom": "^15.3.2",
     "react-hot-loader": "^1.3.0",
     "react-redux": "^4.4.5",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "redux": "^3.6.0"
   }
 }


### PR DESCRIPTION
There was an issue with `react-tap-event-plugin`: `Error: Cannot resolve module 'react/lib/EventPluginHub'`

This issue is discussed here: https://github.com/zilverline/react-tap-event-plugin/issues/85

Updating `react` and `react-tap-event-plugin` to later versions fixed this